### PR TITLE
Port to JSON::MaybeXS decode_json

### DIFF
--- a/examples/eg1.pl
+++ b/examples/eg1.pl
@@ -1,11 +1,11 @@
 use 5.010;
-use lib "lib";
-use lib "../JSON-JOM/lib";
-use JSON::JOM qw[from_json to_json to_jom];
-use JSON::Path;
+use JSON::MaybeXS;
 use Scalar::Util qw[blessed];
+use lib "../lib";
+use JSON::Path;
 
-my $object = to_jom(from_json(<<'JSON'));
+my $json = JSON::MaybeXS->new( pretty => 1 );
+my $object = $json->decode(<<'JSON');
 {
 	"store": {
 		"book": [
@@ -51,8 +51,8 @@ foreach ('$.store.book[0].title', '$.store.book[*].author', '$..author', '$..boo
 {
 	my $jpath = JSON::Path->new($_);
 	say $jpath;
-	say to_json([$jpath->values($object)], {pretty=>1});
-	say to_json([$jpath->paths($object)], {pretty=>1});
+	say $json->encode([$jpath->values($object)]);
+	say $json->encode([$jpath->paths($object)]);
 	say [$jpath->values($object)]->[0]->nodePath
 		if blessed([$jpath->values($object)]->[0]);
 	say '-' x 40;

--- a/lib/JSON/Path.pm
+++ b/lib/JSON/Path.pm
@@ -9,7 +9,7 @@ our $VERSION   = '0.205';
 our $Safe      = 1;
 
 use Carp;
-use JSON qw[from_json];
+use JSON::MaybeXS qw[decode_json];
 use Scalar::Util qw[blessed];
 use LV ();
 
@@ -54,7 +54,7 @@ sub to_string
 sub _get
 {
 	my ($self, $object, $type) = @_;
-	$object = from_json($object) unless ref $object;
+	$object = decode_json($object) unless ref $object;
 	
 	my $helper = JSON::Path::Helper->new;
 	$helper->{'resultType'} = $type;
@@ -526,7 +526,8 @@ Given a JSONPath expression $string, returns a JSON::Path object.
 
 Evaluates the JSONPath expression against an object. The object $object
 can be either a nested Perl hashref/arrayref structure, or a JSON string
-capable of being decoded by JSON::from_json.
+capable of being decoded by JSON::MaybeXS decode_json (meaning especially
+that it should be UTF-8 encoded!).
 
 Returns a list of structures from within $object which match against the
 JSONPath expression. In scalar context, returns the number of matches.

--- a/lib/JSON/Path.pm
+++ b/lib/JSON/Path.pm
@@ -482,13 +482,15 @@ JSON::Path - search nested hashref/arrayref structures using JSONPath
       },
     ],
     "bicycle" => [
-      { "color": "red",
-        "price": 19.95,
+      { "color" => "red",
+        "price" => 19.95,
       },
     ],
   },
  };
  
+ use JSON::Path 'jpath_map';
+
  # All books in the store
  my $jpath   = JSON::Path->new('$.store.book[*]');
  my @books   = $jpath->values($data);
@@ -498,8 +500,7 @@ JSON::Path - search nested hashref/arrayref structures using JSONPath
  my $tolkien = $jpath->value($data);
  
  # Convert all authors to uppercase
- use JSON::Path 'jpath_map';
- jpath_map { uc $_ } $object, '$.store.book[*].author';
+ jpath_map { uc $_ } $data, '$.store.book[*].author';
 
 =head1 DESCRIPTION
 

--- a/meta/makefile.pret
+++ b/meta/makefile.pret
@@ -1,7 +1,7 @@
 # This file provides instructions for packaging.
 
 `JSON-Path`
-	deps:runtime-requirement  [ deps:on "JSON 2.00"^^deps:CpanId ];
+	deps:runtime-requirement  [ deps:on "JSON::MaybeXS 1.003005"^^deps:CpanId ];
 	deps:runtime-requirement  [ deps:on "Exporter::Tiny"^^deps:CpanId ];
 	deps:runtime-requirement  [ deps:on "LV"^^deps:CpanId ];
 	deps:test-requirement     [ deps:on "Test::More 0.61"^^deps:CpanId ];

--- a/t/07utf8.t
+++ b/t/07utf8.t
@@ -1,0 +1,63 @@
+=head1 PURPOSE
+
+Some basic Tests for handling of unicode characters in JSON data.
+
+=head1 AUTHOR
+
+Heiko Jansen E<lt>hjansen@cpan.orgE<gt>.
+
+=head1 COPYRIGHT AND LICENCE
+
+Copyright 2016 Heiko Jansen.
+
+This module is tri-licensed. It is available under the X11 (a.k.a. MIT)
+licence; you can also redistribute it and/or modify it under the same
+terms as Perl itself.
+
+=cut
+
+use Test::More tests => 5;
+BEGIN { use_ok('JSON::Path') };
+
+use JSON::MaybeXS;
+my $data = <<"JSON";
+{
+	"store": {
+		"book": [
+			{
+				"category": "reference",
+				"author":   "Randal L. Schwartz",
+				"title":    "Einf\xFChrung in Perl",
+				"isbn":     "9783868991451",
+				"price":    34.90
+			},
+			{
+				"category": "chartest",
+				"author":   "\x{61}\x{0300}\x{0320}. u. thor",
+				"title":    "Me \x{2661} Unicode",
+				"price":    0.0
+			}
+		],
+		"bicycle": {
+			"color": "r\xF6tlich",
+			"price": 19.95
+		}
+	}
+}
+JSON
+utf8::encode($data);
+my $object = decode_json($data);
+
+my $path1 = JSON::Path->new('$.store.book[0].title');
+is("$path1", '$.store.book[0].title', "overloaded stringification");
+
+my @results1 = $path1->values($object);
+is($results1[0], "Einf\xFChrung in Perl", "basic value result");
+
+@results1 = $path1->paths($object);
+is($results1[0], "\$['store']['book']['0']['title']", "basic path result");
+
+my $path2 = JSON::Path->new('$.store.book[1].author');
+my @results2 = $path2->values($object);
+is($results2[0], "\x{61}\x{0300}\x{0320}. u. thor", "basic value result");
+


### PR DESCRIPTION
At $work we´re currently looking for ways to access configuration data (to be held in JSON) and I came across your JSON::Path module. It looks like a possible fit for our needs, but I have to admit that we didn´t really do anything with it yet.
While looking at the module code I thought that nowadays JSON::MaybeXS would be my weapon of choice to tackle JSON parsing and it looked like a small change so I just went ahead...
I am, however, not exactly sure if this is the right way to do it, since like always I´m having a hard time figuring out how things should work and do work when non-ascii data is involved.
If you know that going with "use JSON::MaybeXS ':legacy';" and continuing to use "from_json" would be a wiser decision I´ll update the code and create a new pull request.
